### PR TITLE
Embedded Jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,73 +203,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
-                <configuration>
-                    <argLine>-Xmx3g</argLine>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>com.akathist.maven.plugins.launch4j</groupId>
-                <artifactId>launch4j-maven-plugin</artifactId>
-                <version>1.7.8</version>
-                <executions>
-                    <execution>
-                        <id>native-windows</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>launch4j</goal>
-                        </goals>
-                        <configuration>
-                            <!-- hier wird der Dateiname mit dazugehöriger Icon - Datei festgelegt , zusätzlich
-                            wird die ( Download -) URL des Programms festgelegt
-                            -->
-                            <headerType>gui</headerType>
-                            <outfile>target/${project.artifactId}-${project.version}.exe</outfile>
-                            <errTitle>Java Runtime 64 Bit Download</errTitle>
-                            <downloadUrl>http://www.java.com/en/download/manual.jsp</downloadUrl>
-                            <supportUrl>${project.url}</supportUrl>
-                            <icon>src/main/resources/icon.ico</icon>
-                            <!-- Single - Instance definiert , dass das Programm nur einmal gestartet werden kann -->
-                            <singleInstance>
-                                <mutexName>${project.artifactId}</mutexName>
-                                <windowTitle>${project.artifactId}</windowTitle>
-                            </singleInstance>
-                            <!-- dieser Eintrag legt die Parameter der Ausf ¨u hrung fest , JRE und Bit Version ,
-                            sowie Parameter die der JRE zur Ausf ¨u hrung mitgegeben werden
-                            -->
-                            <jre>
-                                <minVersion>1.8.0</minVersion>
-                                <runtimeBits>64</runtimeBits>
-                                <opts>
-                                    <opt>-Xmx5g</opt>
-                                    <opt>-XX:+UseParallelGC</opt>
-                                </opts>
-                            </jre>
-                            <!-- Windows -Datei - Informationen , die angezeigt werden , wenn die Eigenschaften des
-                            Executables angezeigt werden . Diese Eigenschaften m¨u ssen gesetzt werden
-                            -->
-                            <versionInfo>
-                                <fileVersion>${project.version}.0.0</fileVersion>
-                                <txtFileVersion>${project.version}.0.0</txtFileVersion>
-                                <fileDescription></fileDescription>
-                                <copyright>${project.organization.name}</copyright>
-                                <productVersion>${project.version}.0.0</productVersion>
-                                <txtProductVersion>${project.version}.0.0</txtProductVersion>
-                                <productName>${project.artifactId}</productName>
-                                <companyName>${project.organization.name}</companyName>
-                                <internalName>${project.artifactId}-${project.version}.jar</internalName>
-                                <originalFilename>${project.artifactId}-${project.version}.exe</originalFilename>
-                            </versionInfo>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-
             <!-- Clean ist ein Plugin , das speziell f¨ur das Goal " mvn clean " genutzt werden kann , um tempor ¨are Dateien zu l¨o schen .
             Per Default
             l¨o scht Maven den vollst ¨a ndigen " target " Ordner , je nach Bauprozess sind aber noch andere Dateien im Verzeichnis
@@ -292,35 +225,6 @@
                         </fileset>
                     </filesets>
                 </configuration>
-            </plugin>
-
-
-            <plugin>
-                <groupId>sh.tak.appbundler</groupId>
-                <artifactId>appbundle-maven-plugin</artifactId>
-                <version>1.0.4</version>
-                <configuration>
-                    <!-- Parameter f¨ur die JRE bei der Ausf ¨u hrung -->
-                    <jvmOptions>
-                        <jvmOption>-Xmx5g</jvmOption>
-                        <jvmOption>-XX:+UseParallelGC</jvmOption>
-                    </jvmOptions>
-                    <!-- Icon - Datei des Bundles und Datei - Name -->
-                    <iconFile>icon.icns</iconFile>
-                    <generateDiskImageFile>true</generateDiskImageFile>
-                    <bundleName>${project.artifactId}-${project.version}</bundleName>
-                    <!-- Klasse mit der " public static void main ( final String [] p_args )" Methode z.B. myproject . CMain -->
-                    <mainClass>edu.tuc.taxieinstiegstatistik.service</mainClass>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>native-darwin</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>bundle</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <!-- Doxygen kann mit Hilfe dieses Plugins direkt aus Maven heraus gestartet werden . Der Aufruf dazu lautet " mvn site "
@@ -377,7 +281,7 @@
                                         vollst ¨a ndigen Namen (Paket - + Klassenname )
                                         angegeben werden z.B. myproject . CMain
                                         -->
-                                        <Main-Class>edu.tuc.taxieinstiegstatistik.service</Main-Class>
+                                        <Main-Class>edu.tuc.taxieinstiegstatistik.EmbeddedJettye</Main-Class>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.postgis</groupId>
             <artifactId>postgis-jdbc</artifactId>
-            <version>1.3.3</version>
+            <version>1.5.2</version>
         </dependency>
 
         <!-- ENDE DATENBANK -->
@@ -97,23 +97,28 @@
         <dependency>
             <groupId>org.renjin</groupId>
             <artifactId>renjin-script-engine</artifactId>
-            <version>RELEASE</version>
+            <version>0.8.2203</version>
         </dependency>
 
         <!-- Jetty -->
 
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>9.2.3.v20140905</version>
+            <groupId>org.eclipse.jetty.aggregate</groupId>
+            <artifactId>jetty-all-server</artifactId>
+            <version>8.1.19.v20160209</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>9.2.3.v20140905</version>
+            <artifactId>jetty-jsp-2.1</artifactId>
+            <version>7.5.0.RC2</version>
         </dependency>
-        
+
+        <dependency>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>jsp-2.1</artifactId>
+            <version>6.0.0rc4</version>
+        </dependency>
 
         <!-- Ende Jetty -->
 
@@ -123,14 +128,14 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.23.1</version>
+            <version>2.23.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.containers/jersey-container-servlet -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-            <version>2.23.1</version>
+            <version>2.23.2</version>
         </dependency>
 
         <!-- ENDE JERSEY -->
@@ -138,7 +143,7 @@
         <dependency>
    			 <groupId>org.glassfish.jersey.media</groupId>
     		 <artifactId>jersey-media-jaxb</artifactId>
-    		 <version>2.17</version>
+    		 <version>2.23.2</version>
 		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/xmlunit/xmlunit -->
@@ -153,10 +158,11 @@
             <artifactId>commons-cli</artifactId>
             <version>1.3.1</version>
         </dependency>
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.4.0.M0</version>
+            <version>9.4.0.M1</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,11 @@
             <artifactId>commons-cli</artifactId>
             <version>1.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>9.4.0.M0</version>
+        </dependency>
 
     </dependencies>
 
@@ -183,6 +188,9 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>src/main/webapp</directory>
             </resource>
         </resources>
 
@@ -287,7 +295,7 @@
                                         vollst ¨a ndigen Namen (Paket - + Klassenname )
                                         angegeben werden z.B. myproject . CMain
                                         -->
-                                        <Main-Class>edu.tuc.taxieinstiegstatistik.EmbeddedJettye</Main-Class>
+                                        <Main-Class>edu.tuc.taxieinstiegstatistik.EmbeddedJetty</Main-Class>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
     		<version>1.6</version>
 		</dependency>
 
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,16 @@
                                     </manifestEntries>
                                 </transformer>
                             </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
+++ b/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
@@ -33,12 +33,14 @@ public final class EmbeddedJetty
      */
     private EmbeddedJetty(final InetSocketAddress p_bind ) throws Exception
     {
+        final String l_context = EmbeddedJetty.class.getProtectionDomain().getCodeSource().getLocation().toExternalForm();
+
         // WebAppContext, um die web.xml zu verarbeiten
         final WebAppContext l_webapp = new WebAppContext();
-        l_webapp.setContextPath( "/" );
+        l_webapp.setResourceBase( "." );
+        l_webapp.setDescriptor( "WEB-INF/web.xml" );
+        l_webapp.setContextPath( l_context.substring( 0, l_context.length()-1 ) );
 
-        l_webapp.setDescriptor( EmbeddedJetty.class.getResource("/WEB-INF/web.xml").toString() );
-        //l_webapp.setResourceBase( EmbeddedJetty.class.getResource("").toString() );
 
         final Server l_server = new Server( p_bind );
         l_server.setHandler( l_webapp );

--- a/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
+++ b/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
@@ -1,27 +1,85 @@
 package edu.tuc.taxieinstiegstatistik;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.eclipse.jetty.server.Server;
+
+import java.net.InetSocketAddress;
+
 /**
  * Main-Klasse, um Jetty mit der Anwendung zu starten
  */
 public final class EmbeddedJetty
 {
+    /**
+     * Default-Host-Adresse
+     */
+    private static final String DEFAULTHOST = "localhost";
+    /**
+     * Default-Host-Port
+     */
+    private static final String DEFAULTPORT = "8080";
+
 
     /**
      * privater ctor, damit keine zwei Jetty-Instanzen laufen können,
      * Jetty Instanz wird aber hier gestartet
+     *
+     * @param p_bind Binding Adresse
      */
-    private EmbeddedJetty()
-    {}
+    private EmbeddedJetty(final InetSocketAddress p_bind )
+    {
+        final Server l_server = new Server( p_bind );
+
+
+    }
 
 
     /**
      * main
-     * @param p_args
+     * @param p_args command-line Argumente
      */
     public static void main( final String[] p_args )
     {
-        // instantiiere hier die Klasse
-        new EmbeddedJetty();
+        // --- definiere Command-Line Parameter ------------------------------------------------------------------------
+
+        final Options l_clioptions = new Options();
+        l_clioptions.addOption( "help", false, "zeigt diese Hilfe" );
+        l_clioptions.addOption( "port", true, "Port des Server (default 8080)" );
+        l_clioptions.addOption( "host", true, "Adresse des Servers (default localhost)" );
+
+        final CommandLine l_cli;
+        try
+        {
+            l_cli = new DefaultParser().parse( l_clioptions, p_args );
+        }
+        catch ( final Exception l_exception )
+        {
+            System.err.println( "Command-Line Parsing Fehler" );
+            System.exit( -1 );
+            return;
+        }
+
+        // --- verarbeite Command-Line Parameter -----------------------------------------------------------------------
+
+        if ( l_cli.hasOption( "help" ) )
+        {
+            new HelpFormatter().printHelp( new java.io.File( EmbeddedJetty.class.getProtectionDomain().getCodeSource().getLocation().getPath() ).getName(), l_clioptions );
+            System.exit( 0 );
+            return;
+        }
+
+
+        // instantiiere hier die Embedded-Jetty-Klasse
+        // und lese aus den Parametern die Daten bzw. nutze die Default-Daten
+        new EmbeddedJetty(
+          new InetSocketAddress(
+            l_cli.getOptionValue( "host", DEFAULTHOST ),
+            Integer.parseInt( l_cli.getOptionValue( "port", DEFAULTPORT ) )
+          )
+        );
     }
 
 

--- a/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
+++ b/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
@@ -33,14 +33,13 @@ public final class EmbeddedJetty
      */
     private EmbeddedJetty(final InetSocketAddress p_bind ) throws Exception
     {
-        final String l_context = EmbeddedJetty.class.getProtectionDomain().getCodeSource().getLocation().toExternalForm();
 
         // WebAppContext, um die web.xml zu verarbeiten
-        final WebAppContext l_webapp = new WebAppContext();
-        l_webapp.setResourceBase( "." );
+        final WebAppContext l_webapp = new WebAppContext(
+                this.getClass().getProtectionDomain().getCodeSource().getLocation().toExternalForm(),
+                "/"
+        );
         l_webapp.setDescriptor( "WEB-INF/web.xml" );
-        l_webapp.setContextPath( l_context.substring( 0, l_context.length()-1 ) );
-
 
         final Server l_server = new Server( p_bind );
         l_server.setHandler( l_webapp );

--- a/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
+++ b/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
@@ -5,6 +5,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.webapp.WebAppContext;
 
 import java.net.InetSocketAddress;
 
@@ -28,20 +29,29 @@ public final class EmbeddedJetty
      * Jetty Instanz wird aber hier gestartet
      *
      * @param p_bind Binding Adresse
+     * @throws Exception bei Initialisierungsfehler
      */
-    private EmbeddedJetty(final InetSocketAddress p_bind )
+    private EmbeddedJetty(final InetSocketAddress p_bind ) throws Exception
     {
+        // WebAppContext, um die web.xml zu verarbeiten
+        final WebAppContext l_webapp = new WebAppContext();
+        l_webapp.setContextPath( "/" );
+
+        l_webapp.setDescriptor( EmbeddedJetty.class.getResource("/WEB-INF/web.xml").toString() );
+        //l_webapp.setResourceBase( EmbeddedJetty.class.getResource("").toString() );
+
         final Server l_server = new Server( p_bind );
-
-
+        l_server.setHandler( l_webapp );
+        l_server.start();
     }
 
 
     /**
      * main
      * @param p_args command-line Argumente
+     * @throws Exception bei Initialisierungsfehler
      */
-    public static void main( final String[] p_args )
+    public static void main( final String[] p_args ) throws Exception
     {
         // --- definiere Command-Line Parameter ------------------------------------------------------------------------
 

--- a/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
+++ b/src/main/java/edu/tuc/taxieinstiegstatistik/EmbeddedJetty.java
@@ -1,0 +1,28 @@
+package edu.tuc.taxieinstiegstatistik;
+
+/**
+ * Main-Klasse, um Jetty mit der Anwendung zu starten
+ */
+public final class EmbeddedJetty
+{
+
+    /**
+     * privater ctor, damit keine zwei Jetty-Instanzen laufen können,
+     * Jetty Instanz wird aber hier gestartet
+     */
+    private EmbeddedJetty()
+    {}
+
+
+    /**
+     * main
+     * @param p_args
+     */
+    public static void main( final String[] p_args )
+    {
+        // instantiiere hier die Klasse
+        new EmbeddedJetty();
+    }
+
+
+}

--- a/src/test/java/edu/tuc/taxieinstiegstatistik/datenbank/DatenbankAdapterTest.java
+++ b/src/test/java/edu/tuc/taxieinstiegstatistik/datenbank/DatenbankAdapterTest.java
@@ -1,11 +1,13 @@
 package edu.tuc.taxieinstiegstatistik.datenbank;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import java.util.Date;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 
+@Ignore
 public class DatenbankAdapterTest {
 
 	@Test

--- a/src/test/java/edu/tuc/taxieinstiegstatistik/datenbank/DatenbankAdapterTest.java
+++ b/src/test/java/edu/tuc/taxieinstiegstatistik/datenbank/DatenbankAdapterTest.java
@@ -7,7 +7,6 @@ import java.util.Date;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 
-@Ignore
 public class DatenbankAdapterTest {
 
 	@Test

--- a/src/test/java/edu/tuc/taxieinstiegstatistik/service/TaxiEinstiegStatistikServiceTest.java
+++ b/src/test/java/edu/tuc/taxieinstiegstatistik/service/TaxiEinstiegStatistikServiceTest.java
@@ -7,9 +7,11 @@ import java.net.URL;
 
 import org.custommonkey.xmlunit.XMLTestCase;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
+@Ignore
 public class TaxiEinstiegStatistikServiceTest extends XMLTestCase {
 	/**
 	 * Test Klasse TaxiEinstiegStatistikService
@@ -23,7 +25,7 @@ public class TaxiEinstiegStatistikServiceTest extends XMLTestCase {
 		TaxiEinstiegStatistikService testTESS = new TaxiEinstiegStatistikService();	
 		Assert.assertTrue(testTESS.getEinstiegStatistik("00:00:00", "24:00:00") instanceof KML);	
 	}
-*/	
+*/
 	@Test
 	public void testXMLContent() throws IOException, SAXException {
 		//Test auf XML- Inhalt: wenn Tag </coordinates> enthalten dann xml valide 

--- a/src/test/java/edu/tuc/taxieinstiegstatistik/service/TaxiEinstiegStatistikServiceTest.java
+++ b/src/test/java/edu/tuc/taxieinstiegstatistik/service/TaxiEinstiegStatistikServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
-@Ignore
 public class TaxiEinstiegStatistikServiceTest extends XMLTestCase {
 	/**
 	 * Test Klasse TaxiEinstiegStatistikService


### PR DESCRIPTION
Habe Euch einmal das Embedded Jetty eingebaut. Damit müsste sich die Jar direkt inkl Euren gesamten Inhalten ausführen lassen. Wenn Ihr "java -jar TaxiStatistik.jar -help" eingebt, dann könnt Ihr auch Port und Hostname manuell setzen. Die Main startet dann den Jetty Server und bindet das, was in der web.xml konfiguriert ist direkt ein. Ich musste allerdings dazu einige Pakete in die pom.xml ändern bzw. hinzufügen. Insbesondere habe ich die Main etwas trickreich implementiert, schaut es Euch einmal an und überlegt Euch, warum das so sinnvoll ist. 
Ich konnte allerdings das ganze nicht testen, da ich jetzt keine Datenbankkonfiguration hatte bzw auch auf die Schnelle nicht wusste, wie die Konfiguration aussehen müsste, evtl wäre dazu ganz gut, wenn Ihr an das Jar noch eine Option "-generateconfig" bauen würdet, die eine Beispielkonfig erzeugt, wo ich dann nur meine Daten ändern muss.

Ansonsten sehe ich die Weboberfläche, natürlich aktuell ohne Daten und es funktioniert auch soweit, das was ich testen konnte. Die Optik der Weboberfläche ist Euch sehr gut gelungen. 
Code sehen intern auch recht ordentlich aus, sind nur ein paar kleinere unschönere Sachen drin z.B. ihr müsstet bei Generics, damit keine Compilerwarnung kommt immer die <> angeben. 
Absolut sehr schöne Arbeit!! Super gemacht, ich freue mich da auf Eure Präsentation. Top Arbeit in allen Punkten und gut umgesetzt.

Hatte bei dem ersten Pull-RAequest vergessen die Signaturen der Jars innerhalb der pom.xml zu ignorieren. Das ist jetzt mit im Pull-Request enthalten
